### PR TITLE
Add simple integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,18 +51,20 @@ jobs:
   test:
     machine: true
     steps:
+      - run: echo "export PATH=\"$CIRCLE_WORKING_DIRECTORY:\$PATH\"" >> $BASH_ENV
+
       - run: docker info
 
       - run: wget -O kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 && chmod +x kind
-      - run: ./kind create cluster --image kindest/node:v1.14.2
-      - run: echo 'export KUBECONFIG="$(./kind get kubeconfig-path)"' >> $BASH_ENV
+      - run: kind create cluster --image kindest/node:v1.14.2
+      - run: echo 'export KUBECONFIG="$(kind get kubeconfig-path)"' >> $BASH_ENV
 
       - run: wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux/amd64/kubectl && chmod +x kubectl
-      - run: ./kubectl version
+      - run: kubectl version
 
       - run: wget https://get.helm.sh/helm-v2.14.1-linux-amd64.tar.gz && tar -xzf helm-v2.14.1-linux-amd64.tar.gz --strip-components 1 linux-amd64/helm
-      - run: ./helm init --wait
-      - run: ./helm version
+      - run: helm init --wait
+      - run: helm version
 
   deploy:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - checkout
       - run: dep ensure
-
       - persist_to_workspace:
           root: vendor
           paths:
@@ -34,14 +33,11 @@ jobs:
           name: Installing Gox
           command: go get github.com/mitchellh/gox
       - checkout
-
       - attach_workspace:
           at: vendor
-
       - run: >
           gox -osarch "darwin/amd64 linux/amd64"
           -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
-
       - persist_to_workspace:
           root: dist
           paths:
@@ -61,28 +57,24 @@ jobs:
       - run: |
           wget -O kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64
           chmod +x kind
-
       - run: kind create cluster --image kindest/node:v1.14.2
-
       - run: |
           echo 'export KUBECONFIG="$(kind get kubeconfig-path)"' >> $BASH_ENV
-
       - run: |
           wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux/amd64/kubectl
           chmod +x kubectl
-
       - run: kubectl version
 
       - run: |
           wget https://get.helm.sh/helm-v2.14.1-linux-amd64.tar.gz
           tar -xzf helm-v2.14.1-linux-amd64.tar.gz --strip-components 1 linux-amd64/helm
-
-      - run: helm init --wait
+      - run: |
+          kubectl apply -f test/rbac-config.yaml
+          helm init --service-account tiller --wait
       - run: helm version
 
       - attach_workspace:
           at: dist
-
       - run: |
           mkdir $HOME/.helm/plugins/helm-edit
           cp plugin.yaml $HOME/.helm/plugins/helm-edit/
@@ -98,12 +90,9 @@ jobs:
       - run:
           name: Installing ghr
           command: go get -u github.com/tcnksm/ghr
-
       - checkout
-
       - attach_workspace:
           at: dist
-
       - deploy:
           command: >
             ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
     docker:
       - image: docker:18.09
     steps:
+      - run: docker info
       - run: wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 && chmod +x /usr/local/bin/kind
       - run: kind create cluster --loglevel debug
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
       - run: kind create cluster --image kindest/node:v1.14.2
 
       - run: wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
+      - run: kubectl config view --kubeconfig "$(kind get kubeconfig-path)" -o jsonpath='{.clusters[?(@.name == "kind")].cluster.server}'
       - run: kubectl version --kubeconfig "$(kind get kubeconfig-path)"
 
       - run: wget https://get.helm.sh/helm-v2.14.1-linux-amd64.tar.gz && tar -xzf helm-v2.14.1-linux-amd64.tar.gz -C /usr/local/bin --strip-components 1 linux-amd64/helm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
     <<: *defaults
     steps:
       - run: GO111MODULE="on" go get sigs.k8s.io/kind@v0.3.0
+      - run: kind create cluster
 
   deploy:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - image: docker:18.09
     steps:
       - run: wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 && chmod +x /usr/local/bin/kind
-      - run: kind create cluster
+      - run: kind create cluster --loglevel debug
 
   deploy:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
       - run:
           name: Running gometalinter
           command: gometalinter --deadline=5m --errors
+
   build:
     <<: *defaults
     steps:
@@ -46,6 +47,11 @@ jobs:
           paths:
             - helm-edit_darwin_amd64
             - helm-edit_linux_amd64
+
+  test:
+    <<: *defaults
+    steps:
+      - run: GO111MODULE="on" go get sigs.k8s.io/kind@v0.3.0
 
   deploy:
     <<: *defaults
@@ -77,9 +83,15 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - deploy:
+      - test:
           requires:
             - build
+          filters:
+            tags:
+              only: /.*/
+      - deploy:
+          requires:
+            - test
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,9 @@ jobs:
           cp dist/helm-edit_linux_amd64 $HOME/.helm/plugins/helm-edit/helm-edit
 
       - run:
-          command: helm upgrade foo ./foo -i
+          command: |
+            helm upgrade foo ./foo -i
+            diff -B <(helm get values -a foo) <(helm edit -a -e /bin/cat foo)
           working_directory: test
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,22 +49,20 @@ jobs:
             - helm-edit_linux_amd64
 
   test:
-    docker:
-      - image: docker:18.09
+    machine: true
     steps:
-      - setup_remote_docker
       - run: docker info
 
-      - run: wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 && chmod +x /usr/local/bin/kind
-      - run: kind create cluster --image kindest/node:v1.14.2
+      - run: wget -O kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 && chmod +x kind
+      - run: ./kind create cluster --image kindest/node:v1.14.2
+      - run: echo 'export KUBECONFIG="$(./kind get kubeconfig-path)"' >> $BASH_ENV
 
-      - run: wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
-      - run: kubectl config view --kubeconfig "$(kind get kubeconfig-path)" -o jsonpath='{.clusters[?(@.name == "kind")].cluster.server}'
-      - run: kubectl version --kubeconfig "$(kind get kubeconfig-path)"
+      - run: wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux/amd64/kubectl && chmod +x kubectl
+      - run: ./kubectl version
 
-      - run: wget https://get.helm.sh/helm-v2.14.1-linux-amd64.tar.gz && tar -xzf helm-v2.14.1-linux-amd64.tar.gz -C /usr/local/bin --strip-components 1 linux-amd64/helm
-      - run: helm init --kubeconfig "$(kind get kubeconfig-path)"
-      - run: helm version --kubeconfig "$(kind get kubeconfig-path)"
+      - run: wget https://get.helm.sh/helm-v2.14.1-linux-amd64.tar.gz && tar -xzf helm-v2.14.1-linux-amd64.tar.gz --strip-components 1 linux-amd64/helm
+      - run: ./helm init --wait
+      - run: ./helm version
 
   deploy:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       - run: docker info
 
       - run: wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 && chmod +x /usr/local/bin/kind
-      - run: kind create cluster --loglevel debug
+      - run: kind create cluster
 
   deploy:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,13 +59,11 @@ jobs:
       - run: kind create cluster --image kindest/node:v1.14.2
 
       - run: wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
-      - run: export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-      - run: kubectl version
+      - run: kubectl version --kubeconfig "$(kind get kubeconfig-path)"
 
       - run: wget https://get.helm.sh/helm-v2.14.1-linux-amd64.tar.gz && tar -xzf helm-v2.14.1-linux-amd64.tar.gz -C /usr/local/bin --strip-components 1 linux-amd64/helm
-      - run: export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-      - run: helm init
-      - run: helm version
+      - run: helm init --kubeconfig "$(kind get kubeconfig-path)"
+      - run: helm version --kubeconfig "$(kind get kubeconfig-path)"
 
   deploy:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,10 @@ jobs:
             - helm-edit_linux_amd64
 
   test:
-    <<: *defaults
+    docker:
+      - image: docker:18.09
     steps:
-      - run: GO111MODULE="on" go get sigs.k8s.io/kind@v0.3.0
+      - run: wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 && chmod +x /usr/local/bin/kind
       - run: kind create cluster
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,20 +51,46 @@ jobs:
   test:
     machine: true
     steps:
-      - run: echo "export PATH=\"$CIRCLE_WORKING_DIRECTORY:\$PATH\"" >> $BASH_ENV
+      - checkout
+
+      - run: |
+          echo "export PATH=\"$CIRCLE_WORKING_DIRECTORY:\$PATH\"" >> $BASH_ENV
 
       - run: docker info
 
-      - run: wget -O kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 && chmod +x kind
-      - run: kind create cluster --image kindest/node:v1.14.2
-      - run: echo 'export KUBECONFIG="$(kind get kubeconfig-path)"' >> $BASH_ENV
+      - run: |
+          wget -O kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64
+          chmod +x kind
 
-      - run: wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux/amd64/kubectl && chmod +x kubectl
+      - run: kind create cluster --image kindest/node:v1.14.2
+
+      - run: |
+          echo 'export KUBECONFIG="$(kind get kubeconfig-path)"' >> $BASH_ENV
+
+      - run: |
+          wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux/amd64/kubectl
+          chmod +x kubectl
+
       - run: kubectl version
 
-      - run: wget https://get.helm.sh/helm-v2.14.1-linux-amd64.tar.gz && tar -xzf helm-v2.14.1-linux-amd64.tar.gz --strip-components 1 linux-amd64/helm
+      - run: |
+          wget https://get.helm.sh/helm-v2.14.1-linux-amd64.tar.gz
+          tar -xzf helm-v2.14.1-linux-amd64.tar.gz --strip-components 1 linux-amd64/helm
+
       - run: helm init --wait
       - run: helm version
+
+      - attach_workspace:
+          at: dist
+
+      - run: |
+          mkdir $HOME/.helm/plugins/helm-edit
+          cp plugin.yaml $HOME/.helm/plugins/helm-edit/
+          cp dist/helm-edit_linux_amd64 $HOME/.helm/plugins/helm-edit/helm-edit
+
+      - run:
+          command: helm upgrade foo ./foo -i
+          working_directory: test
 
   deploy:
     <<: *defaults
@@ -72,6 +98,7 @@ jobs:
       - run:
           name: Installing ghr
           command: go get -u github.com/tcnksm/ghr
+
       - checkout
 
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,16 @@ jobs:
       - run: docker info
 
       - run: wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 && chmod +x /usr/local/bin/kind
-      - run: kind create cluster
+      - run: kind create cluster --image kindest/node:v1.14.2
+
+      - run: wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.2/bin/linux/amd64/kubectl && chmod +x /usr/local/bin/kubectl
+      - run: export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+      - run: kubectl version
+
+      - run: wget https://get.helm.sh/helm-v2.14.1-linux-amd64.tar.gz && tar -xzf helm-v2.14.1-linux-amd64.tar.gz -C /usr/local/bin --strip-components 1 linux-amd64/helm
+      - run: export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+      - run: helm init
+      - run: helm version
 
   deploy:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,9 @@ jobs:
     docker:
       - image: docker:18.09
     steps:
+      - setup_remote_docker
       - run: docker info
+
       - run: wget -O /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64 && chmod +x /usr/local/bin/kind
       - run: kind create cluster --loglevel debug
 

--- a/test/foo/.helmignore
+++ b/test/foo/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/test/foo/Chart.yaml
+++ b/test/foo/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: foo
+version: 0.1.0

--- a/test/foo/templates/NOTES.txt
+++ b/test/foo/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "foo.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "foo.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "foo.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "foo.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/test/foo/templates/_helpers.tpl
+++ b/test/foo/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "foo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "foo.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "foo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/test/foo/templates/deployment.yaml
+++ b/test/foo/templates/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "foo.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "foo.name" . }}
+    helm.sh/chart: {{ include "foo.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "foo.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "foo.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/test/foo/templates/ingress.yaml
+++ b/test/foo/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "foo.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "foo.name" . }}
+    helm.sh/chart: {{ include "foo.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/test/foo/templates/service.yaml
+++ b/test/foo/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "foo.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "foo.name" . }}
+    helm.sh/chart: {{ include "foo.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "foo.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/test/foo/templates/tests/test-connection.yaml
+++ b/test/foo/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "foo.fullname" . }}-test-connection"
+  labels:
+    app.kubernetes.io/name: {{ include "foo.name" . }}
+    helm.sh/chart: {{ include "foo.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "foo.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/test/foo/values.yaml
+++ b/test/foo/values.yaml
@@ -1,0 +1,49 @@
+# Default values for foo.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  tag: stable
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/test/rbac-config.yaml
+++ b/test/rbac-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system


### PR DESCRIPTION
This PR adds a simple integration test which compares the output of the plugin using `/bin/cat` as an editor with the output of the `helm get values -a` command.

It uses [Kubernetes IN Docker](https://github.com/kubernetes-sigs/kind) to spin up a new cluster, install Helm and deploy a sample Helm chart.